### PR TITLE
Insert missing line break on second slide

### DIFF
--- a/_posts/0000-01-02-verenamarx.md
+++ b/_posts/0000-01-02-verenamarx.md
@@ -4,4 +4,5 @@ title: "Welcome to our second slide!"
 ---
 > Coffee. The finest organic suspension ever devised... I beat the Borg with it.
 > - Captain Janeway
+
 Use the left arrow to go back!


### PR DESCRIPTION
This PR fixes #4, adding a missing line break on the second slide. For a preview of the change, have a look at https://christian-marx.github.io/github-slideshow/#/1.